### PR TITLE
Append `index.html` to file path for URL without path component

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ var url_to_path = module.exports.url_to_path = function(url, opts) {
 	// exorcise any trailing "/"
 	p = path.join(path.dirname(p), path.basename(p));
 
-	if (!opts.noindex && path.extname(p) === "" && !urlparse.parse(url).query) {
+	if (urlparse.parse(url).path.length <= 1 || (!opts.noindex && path.extname(p) === "" && !urlparse.parse(url).query)) {
 		log.verbose("Resolving", p, "to", p + "/index.html.");
 		p += "/index.html";
 	} else if (opts.noindex) {

--- a/index.js
+++ b/index.js
@@ -64,11 +64,12 @@ module.exports = function(url, my_opts, callback) {
 }
 
 var url_to_path = module.exports.url_to_path = function(url, opts) {
-	var p = path.join(urlparse.parse(url).hostname, urlparse.parse(url).path);
+	var parsedUrl = urlparse.parse(url);
+	var p = path.join(parsedUrl.hostname, parsedUrl.path);
 	// exorcise any trailing "/"
 	p = path.join(path.dirname(p), path.basename(p));
 
-	if (urlparse.parse(url).path.length <= 1 || (!opts.noindex && path.extname(p) === "" && !urlparse.parse(url).query)) {
+	if (parsedUrl.path.length <= 1 || (!opts.noindex && path.extname(p) === "" && !parsedUrl.query)) {
 		log.verbose("Resolving", p, "to", p + "/index.html.");
 		p += "/index.html";
 	} else if (opts.noindex) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
 var downcache = require("../index"),
+	assert = require("assert"),
 	rimraf = require("rimraf");
 
 downcache.set({
 	log: "verbose",
 	limit: 2000
 });
+
+assert.equal(downcache.url_to_path("http://example.com", {}), "example.com/index.html");
 
 // remove old cache from previous tests
 rimraf("./cache", function(err) {


### PR DESCRIPTION
Currently, using downcache to download `http://example.com` puts the file at `./cache/example.com`. If I then try to download `http://example.com/path/to/file.html`, I can't, because it would be saved to `./cache/example.com/path/to/file.html`, but `./cache/example.com` is a file, not a directory.

This fixes that by appending `/index.html` if the URL path is empty or just `/`.